### PR TITLE
Add flags

### DIFF
--- a/include/stdcorelib/flags.h
+++ b/include/stdcorelib/flags.h
@@ -1,0 +1,302 @@
+#ifndef STDCORELIB_FLAGS_H
+#define STDCORELIB_FLAGS_H
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <initializer_list>
+#include <type_traits>
+#include <utility>
+
+namespace stdc {
+
+    class flag {
+    public:
+        constexpr explicit flag(int value) noexcept : m_value(value) {
+        }
+
+        constexpr operator int() const noexcept {
+            return m_value;
+        }
+
+    private:
+        int m_value;
+    };
+
+    class incompatible_flag {
+    public:
+        constexpr explicit incompatible_flag(int value) noexcept : m_value(value) {
+        }
+
+        constexpr operator int() const noexcept {
+            return m_value;
+        }
+
+    private:
+        int m_value;
+    };
+
+    namespace detail {
+
+        template <size_t N>
+        struct integer_for_size;
+
+        template <>
+        struct integer_for_size<1> {
+            using Signed = int8_t;
+            using Unsigned = uint8_t;
+        };
+
+        template <>
+        struct integer_for_size<2> {
+            using Signed = int16_t;
+            using Unsigned = uint16_t;
+        };
+
+        template <>
+        struct integer_for_size<4> {
+            using Signed = int32_t;
+            using Unsigned = uint32_t;
+        };
+
+        template <>
+        struct integer_for_size<8> {
+            using Signed = int64_t;
+            using Unsigned = uint64_t;
+        };
+
+        template <class Enum>
+        class flags_storage {
+            static_assert(sizeof(Enum) <= sizeof(uint64_t), "Only enumerations up to 64 bits are supported.");
+            static_assert(std::is_enum<Enum>::value, "flags is only usable on enumeration types.");
+
+            static constexpr size_t IntegerSize = (std::max)(sizeof(Enum), sizeof(int));
+            using Integers = integer_for_size<IntegerSize>;
+
+        protected:
+            using Int = typename std::conditional<
+                std::is_unsigned<typename std::underlying_type<Enum>::type>::value,
+                typename Integers::Unsigned,
+                typename Integers::Signed>::type;
+
+            Int i = 0;
+
+        public:
+            constexpr flags_storage() noexcept = default;
+            constexpr explicit flags_storage(std::in_place_t, Int value) noexcept : i(value) {
+            }
+        };
+
+        template <class Enum, int Size = sizeof(flags_storage<Enum>)>
+        struct flags_storage_helper : flags_storage<Enum> {
+            using flags_storage<Enum>::flags_storage;
+        };
+
+        template <class Enum>
+        struct flags_storage_helper<Enum, sizeof(int)> : flags_storage<Enum> {
+            using flags_storage<Enum>::flags_storage;
+
+            constexpr flags_storage_helper(flag f) noexcept : flags_storage<Enum>(std::in_place, f.operator int()) {
+            }
+        };
+
+    }
+
+    template <class Enum>
+    class flags : public detail::flags_storage_helper<Enum> {
+        using Base = detail::flags_storage_helper<Enum>;
+
+    public:
+        using enum_type = Enum;
+        using Int = typename Base::Int;
+        using Base::Base;
+
+        constexpr flags() noexcept = default;
+        constexpr flags(Enum value) noexcept : Base(std::in_place, Int(value)) {
+        }
+
+        constexpr flags(std::initializer_list<Enum> values) noexcept
+            : Base(std::in_place, initializer_list_helper(values.begin(), values.end())) {
+        }
+
+        static constexpr flags fromInt(Int value) noexcept {
+            return flags(std::in_place, value);
+        }
+
+        constexpr Int toInt() const noexcept {
+            return i;
+        }
+
+        constexpr flags &operator&=(flags mask) noexcept {
+            i &= mask.i;
+            return *this;
+        }
+
+        constexpr flags &operator&=(Enum mask) noexcept {
+            i &= Int(mask);
+            return *this;
+        }
+
+        constexpr flags &operator|=(flags other) noexcept {
+            i |= other.i;
+            return *this;
+        }
+
+        constexpr flags &operator|=(Enum other) noexcept {
+            i |= Int(other);
+            return *this;
+        }
+
+        constexpr flags &operator^=(flags other) noexcept {
+            i ^= other.i;
+            return *this;
+        }
+
+        constexpr flags &operator^=(Enum other) noexcept {
+            i ^= Int(other);
+            return *this;
+        }
+
+        constexpr explicit operator Int() const noexcept {
+            return i;
+        }
+
+        constexpr explicit operator bool() const noexcept {
+            return i != Int(0);
+        }
+
+        constexpr flags operator|(flags other) const noexcept {
+            return flags(std::in_place, i | other.i);
+        }
+
+        constexpr flags operator|(Enum other) const noexcept {
+            return flags(std::in_place, i | Int(other));
+        }
+
+        constexpr flags operator^(flags other) const noexcept {
+            return flags(std::in_place, i ^ other.i);
+        }
+
+        constexpr flags operator^(Enum other) const noexcept {
+            return flags(std::in_place, i ^ Int(other));
+        }
+
+        constexpr flags operator&(flags other) const noexcept {
+            return flags(std::in_place, i & other.i);
+        }
+
+        constexpr flags operator&(Enum other) const noexcept {
+            return flags(std::in_place, i & Int(other));
+        }
+
+        constexpr flags operator~() const noexcept {
+            return flags(std::in_place, ~i);
+        }
+
+        constexpr void operator+(flags) const noexcept = delete;
+        constexpr void operator+(Enum) const noexcept = delete;
+        constexpr void operator+(int) const noexcept = delete;
+        constexpr void operator-(flags) const noexcept = delete;
+        constexpr void operator-(Enum) const noexcept = delete;
+        constexpr void operator-(int) const noexcept = delete;
+
+        constexpr bool test_flag(Enum value) const noexcept {
+            return testFlags(value);
+        }
+
+        constexpr bool test_flags(flags values) const noexcept {
+            return values.i ? ((i & values.i) == values.i) : i == Int(0);
+        }
+
+        constexpr bool test_any_flag(Enum value) const noexcept {
+            return testAnyFlags(value);
+        }
+
+        constexpr bool test_any_flags(flags values) const noexcept {
+            return (i & values.i) != Int(0);
+        }
+
+        constexpr flags &set_flag(Enum value, bool on = true) noexcept {
+            return on ? (*this |= value) : (*this &= ~flags(value));
+        }
+
+        friend constexpr bool operator==(flags lhs, flags rhs) noexcept {
+            return lhs.i == rhs.i;
+        }
+
+        friend constexpr bool operator!=(flags lhs, flags rhs) noexcept {
+            return lhs.i != rhs.i;
+        }
+
+        friend constexpr bool operator==(flags lhs, Enum rhs) noexcept {
+            return lhs == flags(rhs);
+        }
+
+        friend constexpr bool operator!=(flags lhs, Enum rhs) noexcept {
+            return lhs != flags(rhs);
+        }
+
+        friend constexpr bool operator==(Enum lhs, flags rhs) noexcept {
+            return flags(lhs) == rhs;
+        }
+
+        friend constexpr bool operator!=(Enum lhs, flags rhs) noexcept {
+            return flags(lhs) != rhs;
+        }
+
+    private:
+        static constexpr Int initializer_list_helper(typename std::initializer_list<Enum>::const_iterator it,
+                                                     typename std::initializer_list<Enum>::const_iterator end) noexcept {
+            return it == end ? Int(0) : (Int(*it) | initializer_list_helper(it + 1, end));
+        }
+
+        using Base::i;
+    };
+
+}
+
+#define STDC_DECLARE_FLAGS(Flags, Enum)                                                            \
+    using Flags = ::stdc::flags<Enum>;
+
+#define STDC_DECLARE_OPERATORS_FOR_FLAGS(Flags)                                                    \
+    [[maybe_unused]] constexpr inline ::stdc::flags<typename Flags::enum_type>                    \
+    operator|(typename Flags::enum_type lhs, typename Flags::enum_type rhs) noexcept {            \
+        return ::stdc::flags<typename Flags::enum_type>(lhs) | rhs;                               \
+    }                                                                                              \
+    [[maybe_unused]] constexpr inline ::stdc::flags<typename Flags::enum_type>                    \
+    operator|(typename Flags::enum_type lhs, ::stdc::flags<typename Flags::enum_type> rhs) noexcept { \
+        return rhs | lhs;                                                                          \
+    }                                                                                              \
+    [[maybe_unused]] constexpr inline ::stdc::flags<typename Flags::enum_type>                    \
+    operator&(typename Flags::enum_type lhs, typename Flags::enum_type rhs) noexcept {            \
+        return ::stdc::flags<typename Flags::enum_type>(lhs) & rhs;                               \
+    }                                                                                              \
+    [[maybe_unused]] constexpr inline ::stdc::flags<typename Flags::enum_type>                    \
+    operator&(typename Flags::enum_type lhs, ::stdc::flags<typename Flags::enum_type> rhs) noexcept { \
+        return rhs & lhs;                                                                          \
+    }                                                                                              \
+    [[maybe_unused]] constexpr inline ::stdc::flags<typename Flags::enum_type>                    \
+    operator^(typename Flags::enum_type lhs, typename Flags::enum_type rhs) noexcept {            \
+        return ::stdc::flags<typename Flags::enum_type>(lhs) ^ rhs;                               \
+    }                                                                                              \
+    [[maybe_unused]] constexpr inline ::stdc::flags<typename Flags::enum_type>                    \
+    operator^(typename Flags::enum_type lhs, ::stdc::flags<typename Flags::enum_type> rhs) noexcept { \
+        return rhs ^ lhs;                                                                          \
+    }                                                                                              \
+    constexpr inline void operator+(typename Flags::enum_type, typename Flags::enum_type) noexcept = delete; \
+    constexpr inline void operator+(typename Flags::enum_type, ::stdc::flags<typename Flags::enum_type>) noexcept = delete; \
+    constexpr inline void operator+(int, ::stdc::flags<typename Flags::enum_type>) noexcept = delete; \
+    constexpr inline void operator-(typename Flags::enum_type, typename Flags::enum_type) noexcept = delete; \
+    constexpr inline void operator-(typename Flags::enum_type, ::stdc::flags<typename Flags::enum_type>) noexcept = delete; \
+    constexpr inline void operator-(int, ::stdc::flags<typename Flags::enum_type>) noexcept = delete; \
+    constexpr inline void operator+(int, typename Flags::enum_type) noexcept = delete;            \
+    constexpr inline void operator+(typename Flags::enum_type, int) noexcept = delete;            \
+    constexpr inline void operator-(int, typename Flags::enum_type) noexcept = delete;            \
+    constexpr inline void operator-(typename Flags::enum_type, int) noexcept = delete;            \
+    [[maybe_unused]] constexpr inline ::stdc::flags<typename Flags::enum_type>                    \
+    operator~(typename Flags::enum_type value) noexcept {                                          \
+        return ~Flags(value);                                                                      \
+    }                                                                                              \
+    [[maybe_unused]] constexpr inline void operator|(typename Flags::enum_type, int) noexcept = delete;
+
+#endif // STDCORELIB_FLAGS_H

--- a/tests/auto/test_flags.cpp
+++ b/tests/auto/test_flags.cpp
@@ -1,0 +1,78 @@
+#include <stdcorelib/flags.h>
+
+#include <boost/test/unit_test.hpp>
+
+#include <cstdint>
+#include <type_traits>
+
+using namespace stdc;
+
+namespace {
+
+    enum class Permission {
+        None = 0,
+        Read = 0x01,
+        Write = 0x02,
+        Execute = 0x04
+    };
+
+    STDC_DECLARE_FLAGS(Permissions, Permission)
+    STDC_DECLARE_OPERATORS_FOR_FLAGS(Permissions)
+
+    enum class BigPermission : uint64_t {
+        None = 0,
+        A = 1ull << 40,
+        B = 1ull << 41
+    };
+
+    STDC_DECLARE_FLAGS(BigPermissions, BigPermission)
+    STDC_DECLARE_OPERATORS_FOR_FLAGS(BigPermissions)
+
+}
+
+BOOST_AUTO_TEST_SUITE(test_flags)
+
+BOOST_AUTO_TEST_CASE(test_type_and_construct) {
+    static_assert(std::is_same_v<decltype(Permission::Read | Permission::Write), Permissions>);
+    static_assert(std::is_same_v<decltype(Permission::Read & Permission::Write), Permissions>);
+
+    Permissions perms;
+    BOOST_CHECK(!static_cast<bool>(perms));
+
+    perms = Permission::Read | Permission::Write;
+    BOOST_CHECK(perms.test_flag(Permission::Read));
+    BOOST_CHECK(perms.test_any_flag(Permission::Write));
+    BOOST_CHECK(!perms.test_flag(Permission::Execute));
+
+    Permissions from_list{Permission::Read, Permission::Execute};
+    BOOST_CHECK(from_list.test_flags(Permission::Read | Permission::Execute));
+}
+
+BOOST_AUTO_TEST_CASE(test_set_and_bitops) {
+    Permissions perms = Permission::Read;
+
+    perms.set_flag(Permission::Write);
+    BOOST_CHECK(perms.test_flags(Permission::Read | Permission::Write));
+
+    perms.set_flag(Permission::Read, false);
+    BOOST_CHECK(!perms.test_flag(Permission::Read));
+    BOOST_CHECK(perms == Permission::Write);
+
+    perms ^= Permission::Execute;
+    BOOST_CHECK(perms.test_any_flags(Permission::Write | Permission::Execute));
+
+    auto and_result = perms & Permission::Write;
+    BOOST_CHECK(and_result == Permission::Write);
+}
+
+BOOST_AUTO_TEST_CASE(test_from_to_int_and_64bit_enum) {
+    auto combined = BigPermission::A | BigPermission::B;
+    BOOST_CHECK(combined.test_flag(BigPermission::A));
+    BOOST_CHECK(combined.test_flag(BigPermission::B));
+
+    BigPermissions raw = BigPermissions::fromInt((1ull << 41));
+    BOOST_CHECK(raw == BigPermission::B);
+    BOOST_CHECK_EQUAL(static_cast<uint64_t>(raw.toInt()), (1ull << 41));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This pull request introduces a new generic flags utility to the codebase, providing a type-safe and flexible way to work with bitmask enums in C++. It includes both the implementation of the flags system and a comprehensive set of unit tests to ensure correctness and demonstrate usage. The most important changes are:

### Flags System Implementation

* Added a new header `flags.h` in `include/stdcorelib/`, which defines a generic `flags` template class for type-safe bitmask operations on enum types. It supports enums of varying sizes (including 64-bit), provides a rich set of bitwise operations, and includes macros to easily declare flags types and their operators.

### Testing and Usage Examples

* Added a new test file `test_flags.cpp` in `tests/auto/` containing unit tests for the new flags system. The tests cover construction, bitwise operations, flag setting/clearing, type traits, and support for both regular and large (64-bit) enums.